### PR TITLE
Require website/address in company registration

### DIFF
--- a/client/src/Profiles/EnhancedRegister.jsx
+++ b/client/src/Profiles/EnhancedRegister.jsx
@@ -172,6 +172,8 @@ const initialErrors = {
   profileImage: '',
   name: '',
   industry: '',
+  address: '',
+  website: '',
   phoneCompany: '',
   logo: '',
   email: '',
@@ -369,6 +371,8 @@ const EnhancedRegister = () => {
     if (regRole === 'company') {
       if (!formData.name.trim()) nextErrors.name = 'Company name is required.'
       if (!formData.industry.trim()) nextErrors.industry = 'Industry is required.'
+      if (!formData.address.trim()) nextErrors.address = 'Address is required.'
+      if (!formData.website.trim()) nextErrors.website = 'Website is required.'
       if (!formData.phoneCompany.trim()) nextErrors.phoneCompany = 'Phone number is required.'
       if (!companyLogoFile) nextErrors.logo = 'Company logo is required.'
     }
@@ -713,6 +717,7 @@ const EnhancedRegister = () => {
                       onChange={handleChange}
                       placeholder="Repeat password"
                       required
+                      requiredIndicator
                       error={fieldErrors.confirmPassword}
                       icon={<LockKeyhole className="h-4 w-4" />}
                     />
@@ -729,6 +734,7 @@ const EnhancedRegister = () => {
                     onChange={handleChange}
                     placeholder="TechNova Sdn Bhd"
                     required
+                    requiredIndicator
                     error={fieldErrors.name}
                     icon={<Building2 className="h-4 w-4" />}
                   />
@@ -741,6 +747,7 @@ const EnhancedRegister = () => {
                     options={companyIndustryOptions}
                     selectPlaceholder="Select company industry"
                     required
+                    requiredIndicator
                     error={fieldErrors.industry}
                   />
 
@@ -750,15 +757,21 @@ const EnhancedRegister = () => {
                     value={formData.address}
                     onChange={handleChange}
                     placeholder="123, Main Street, Colombo"
+                    required
+                    requiredIndicator
+                    error={fieldErrors.address}
                   />
 
                   <Field
-                    label="Website (Optional)"
+                    label="Website"
                     name="website"
                     type="url"
                     value={formData.website}
                     onChange={handleChange}
                     placeholder="https://company.com"
+                    required
+                    requiredIndicator
+                    error={fieldErrors.website}
                   />
 
                   <Field
@@ -847,6 +860,7 @@ const EnhancedRegister = () => {
                       onChange={handleChange}
                       placeholder="Repeat password"
                       required
+                      requiredIndicator
                       error={fieldErrors.confirmPassword}
                       icon={<LockKeyhole className="h-4 w-4" />}
                     />

--- a/server/src/controllers/companyController.js
+++ b/server/src/controllers/companyController.js
@@ -32,10 +32,12 @@ const registerCompany = async (req, res, next) => {
         } = req.body;
         const normalizedEmail = email?.trim().toLowerCase();
         const normalizedPhone = phone?.trim();
+        const normalizedAddress = address?.trim();
+        const normalizedWebsite = website?.trim();
         const uploadedLogo = getUploadedFilePath(req.file, "logos", logo);
 
         // Validate required fields
-        if (!name || !industry || !normalizedEmail || !password || !normalizedPhone) {
+        if (!name || !industry || !normalizedEmail || !password || !normalizedPhone || !normalizedAddress || !normalizedWebsite) {
             res.status(400);
             throw new Error("Please provide all required fields");
         }
@@ -84,8 +86,8 @@ const registerCompany = async (req, res, next) => {
             email: normalizedEmail,
             password: hashedPassword,
             phone: normalizedPhone,
-            website,
-            address,
+            website: normalizedWebsite,
+            address: normalizedAddress,
             location,
             contactPerson,
             description,

--- a/server/src/models/Company.js
+++ b/server/src/models/Company.js
@@ -34,10 +34,12 @@ const companySchema = new mongoose.Schema(
         },
         website: {
             type: String,
+            required: [true, "Website is required"],
             trim: true,
         },
         address: {
             type: String,
+            required: [true, "Address is required"],
             trim: true,
         },
         location: {


### PR DESCRIPTION
Enforce website and address as required fields across the stack. Client: added address and website to form errors, made Website label required (removed "Optional"), enabled requiredIndicator and error handling for the fields. Server: normalize trimmed address/website, validate presence in registerCompany, and persist normalized values. Model: mark website and address as required in Company schema with validation messages.