### PR TITLE
Add AI career analysis endpoint and UI

### DIFF
--- a/client/src/api/student_guidance/guidanceApi.js
+++ b/client/src/api/student_guidance/guidanceApi.js
@@ -30,6 +30,20 @@ export const refreshCareerSuggestions = async () => {
   return response.data.data
 }
 
+export const fetchCareerAnalysis = async (careerId, options = {}) => {
+  const params = options.forceRefresh ? { refresh: 'true' } : undefined
+
+  const response = await api.get(
+    `/student-guidance/career-suggestions/${encodeURIComponent(careerId)}/analysis`,
+    {
+      ...getAuthConfig(),
+      params,
+    }
+  )
+
+  return response.data.data
+}
+
 export const streamAskInternConnectMessage = async ({
   message,
   history,

--- a/client/src/components/student_guidance/CareerSuggestionsSection.jsx
+++ b/client/src/components/student_guidance/CareerSuggestionsSection.jsx
@@ -36,11 +36,28 @@ const getScoreTone = (score) => {
   }
 }
 
+const createCareerIdentifier = (career, index = 0) => {
+  if (typeof career?.id === 'string' && career.id.trim()) {
+    return career.id.trim()
+  }
+
+  const titleSlug = String(career?.title || '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+
+  return titleSlug || `career-${index + 1}`
+}
+
 function CareerSuggestionsSection({ aspirations, interests, skills, careerSuggestions, onRefresh, refreshing }) {
   const [searchTerm, setSearchTerm] = useState('')
   const [statusFilter, setStatusFilter] = useState('all')
   const [sortBy, setSortBy] = useState('scoreHigh')
-  const effectiveCareerSuggestions = Array.isArray(careerSuggestions) ? careerSuggestions : []
+  const effectiveCareerSuggestions = useMemo(
+    () => (Array.isArray(careerSuggestions) ? careerSuggestions : []),
+    [careerSuggestions]
+  )
 
   const topScore = effectiveCareerSuggestions.length
     ? Math.max(...effectiveCareerSuggestions.map((career) => normalizeScore(career.matchScore)))
@@ -178,13 +195,14 @@ function CareerSuggestionsSection({ aspirations, interests, skills, careerSugges
 
       {effectiveCareerSuggestions.length > 0 ? (
         <div className="grid gap-5 xl:grid-cols-3">
-          {visibleSuggestions.map((career) => {
+          {visibleSuggestions.map((career, index) => {
             const score = normalizeScore(career.matchScore)
             const tone = getScoreTone(score)
+            const careerId = createCareerIdentifier(career, index)
 
             return (
               <article
-                key={career.title}
+                key={careerId}
                 className={`rounded-2xl border border-l-4 border-[#E8EAF0] p-6 shadow-[0_1px_4px_rgba(0,0,0,0.04)] transition hover:-translate-y-0.5 hover:shadow-[0_8px_18px_rgba(22,34,57,0.08)] ${tone.accent}`}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -208,14 +226,12 @@ function CareerSuggestionsSection({ aspirations, interests, skills, careerSugges
                 </div>
 
                 <p className="mt-4 text-sm leading-6 text-[#5F6C80]">{career.summary}</p>
-                {career.id ? (
-                  <Link
-                    to={`/student-guidance/career/${career.id}`}
-                    className="mt-3 inline-flex rounded-[10px] border border-[#D4E0FA] px-3 py-2 text-xs font-semibold text-[#3B6FE8] transition hover:border-[#BFD4FF] hover:bg-[#EEF2FD] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8DB2FF] focus-visible:ring-offset-2"
-                  >
-                    View comprehensive guide
-                  </Link>
-                ) : null}
+                <Link
+                  to={`/student-guidance/career/${encodeURIComponent(careerId)}`}
+                  className="mt-3 inline-flex rounded-[10px] border border-[#D4E0FA] px-3 py-2 text-xs font-semibold text-[#3B6FE8] transition hover:border-[#BFD4FF] hover:bg-[#EEF2FD] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#8DB2FF] focus-visible:ring-offset-2"
+                >
+                  View full AI analysis
+                </Link>
 
                 <div className="mt-5">
                   <p className="text-sm font-semibold text-[#1A1D27]">Why the AI recommends this</p>

--- a/client/src/pages/CareerRoadmapDetail.jsx
+++ b/client/src/pages/CareerRoadmapDetail.jsx
@@ -1,38 +1,167 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { careerRoadmaps, getCareerRoadmapById } from '../components/student_guidance/careerRoadmaps'
+import { fetchCareerAnalysis, fetchStudentGuidance } from '../api/student_guidance/guidanceApi'
+
+const STATUS_STEPS = [
+  'Analysing your profile signals...',
+  'Generating full AI report...',
+  'Building complete guided roadmap...',
+  'Finalizing recommendations and next steps...',
+]
+
+const createCareerIdentifier = (career, index = 0) => {
+  if (typeof career?.id === 'string' && career.id.trim()) {
+    return career.id.trim()
+  }
+
+  const titleSlug = String(career?.title || '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+
+  return titleSlug || `career-${index + 1}`
+}
 
 function CareerRoadmapDetail() {
   const { careerId } = useParams()
   const navigate = useNavigate()
+  const [career, setCareer] = useState(null)
+  const [careerSuggestions, setCareerSuggestions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [isRegenerating, setIsRegenerating] = useState(false)
+  const [statusIndex, setStatusIndex] = useState(0)
+  const [error, setError] = useState('')
 
-  const career = getCareerRoadmapById(careerId)
+  const loadCareerGuide = useCallback(
+    async ({ forceRefresh = false } = {}) => {
+      try {
+        if (forceRefresh) {
+          setIsRegenerating(true)
+        } else {
+          setLoading(true)
+        }
 
-  if (!career) {
+        setStatusIndex(0)
+        setError('')
+
+        const [analysisData, guidanceData] = await Promise.all([
+          fetchCareerAnalysis(careerId, { forceRefresh }),
+          fetchStudentGuidance().catch(() => null),
+        ])
+
+        setCareer(analysisData)
+        setCareerSuggestions(Array.isArray(guidanceData?.careerSuggestions) ? guidanceData.careerSuggestions : [])
+      } catch (loadError) {
+        setError(loadError.response?.data?.message || 'Unable to load the AI career analysis right now.')
+        setCareer(null)
+      } finally {
+        if (forceRefresh) {
+          setIsRegenerating(false)
+        } else {
+          setLoading(false)
+        }
+      }
+    },
+    [careerId]
+  )
+
+  useEffect(() => {
+    if (careerId) {
+      loadCareerGuide()
+    }
+  }, [careerId, loadCareerGuide])
+
+  const isBusy = loading || isRegenerating
+
+  useEffect(() => {
+    if (!isBusy) {
+      return
+    }
+
+    const statusTimer = setInterval(() => {
+      setStatusIndex((current) => (current + 1) % STATUS_STEPS.length)
+    }, 1200)
+
+    return () => clearInterval(statusTimer)
+  }, [isBusy])
+
+  const statusMessage = STATUS_STEPS[statusIndex]
+
+  const navigateToCareerSuggestions = () => {
+    navigate('/dashboard?tab=guidance', {
+      state: { tab: 'guidance', guidanceTab: 'careers' },
+    })
+  }
+
+  const handleRegenerate = () => {
+    if (!careerId || isBusy) {
+      return
+    }
+
+    loadCareerGuide({ forceRefresh: true })
+  }
+
+  const relatedCareerSuggestions = useMemo(() => {
+    const currentCareerId = String(career?.id || careerId || '').trim()
+
+    return (Array.isArray(careerSuggestions) ? careerSuggestions : [])
+      .filter((item, index) => createCareerIdentifier(item, index) !== currentCareerId)
+      .slice(0, 6)
+  }, [career?.id, careerId, careerSuggestions])
+
+  if (loading) {
     return (
       <div
         className="min-h-screen bg-cover bg-center bg-no-repeat px-4 py-8"
         style={{ backgroundImage: "url('/authbackgound.jpg')" }}
       >
         <section className="mx-auto mt-10 max-w-4xl rounded-2xl border border-dashed border-[#D4E0FA] bg-white/95 p-8 text-center shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
-          <h2 className="font-display text-2xl font-bold text-[#1A1D27]">Career guide not found</h2>
-          <p className="mt-2 text-sm text-[#6B7280]">Choose one of the available role guides to continue.</p>
-          <div className="mt-5 flex justify-center">
+          <h2 className="font-display text-2xl font-bold text-[#1A1D27]">Loading AI Career Guide</h2>
+          <p className="mt-3 animate-pulse text-sm font-semibold text-[#3B6FE8]">{statusMessage}</p>
+        </section>
+      </div>
+    )
+  }
+
+  if (!career || error) {
+    return (
+      <div
+        className="min-h-screen bg-cover bg-center bg-no-repeat px-4 py-8"
+        style={{ backgroundImage: "url('/authbackgound.jpg')" }}
+      >
+        <section className="mx-auto mt-10 max-w-4xl rounded-2xl border border-dashed border-[#D4E0FA] bg-white/95 p-8 text-center shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
+          <h2 className="font-display text-2xl font-bold text-[#1A1D27]">Career guide not available</h2>
+          <p className="mt-2 text-sm text-[#6B7280]">
+            {error || 'The selected career guide could not be loaded.'}
+          </p>
+          <div className="mt-5 flex justify-center gap-3">
             <button
               type="button"
-              onClick={() =>
-                navigate('/dashboard?tab=guidance', {
-                  state: { tab: 'guidance', guidanceTab: 'careers' },
-                })
-              }
+              onClick={navigateToCareerSuggestions}
               className="rounded-[10px] border border-[#E8EAF0] px-4 py-2 text-sm font-semibold text-[#6B7280] transition hover:border-[#CAD8F5] hover:bg-[#F7F8FA]"
             >
-              Go Back
+              Back to Suggestions
+            </button>
+            <button
+              type="button"
+              onClick={handleRegenerate}
+              disabled={isBusy}
+              className="rounded-[10px] border border-[#D4E0FA] bg-white px-4 py-2 text-sm font-semibold text-[#3B6FE8] transition hover:border-[#BFD4FF] hover:bg-[#EEF2FD]"
+            >
+              {isBusy ? 'Regenerating...' : 'Retry Regenerate'}
             </button>
           </div>
         </section>
       </div>
     )
   }
+
+  const strengthsToLeverage = Array.isArray(career.strengthsToLeverage) ? career.strengthsToLeverage : []
+  const skillGaps = Array.isArray(career.skillGaps) ? career.skillGaps : []
+  const roadmap = Array.isArray(career.roadmap) ? career.roadmap : []
+  const guidelines = Array.isArray(career.guidelines) ? career.guidelines : []
+  const matchedAreas = Array.isArray(career.matchedAreas) ? career.matchedAreas : []
 
   return (
     <div
@@ -43,35 +172,92 @@ function CareerRoadmapDetail() {
       <section className="rounded-2xl border border-[#DCE6FB] bg-gradient-to-br from-[#F6FAFF]/95 via-[#FFFFFF]/95 to-[#EEF4FF]/95 p-6 shadow-[0_8px_24px_rgba(42,87,173,0.08)] backdrop-blur-[1px]">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#3B6FE8]">Career Guide</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#3B6FE8]">AI Career Guide</p>
             <h1 className="mt-2 font-display text-3xl font-bold text-[#1A1D27]">{career.title}</h1>
             <p className="mt-2 text-sm text-[#5A6678]">{career.summary}</p>
+            <p className="mt-2 text-xs font-medium uppercase tracking-[0.12em] text-[#6B7280]">
+              Full analysis and roadmap generated from your profile signals.
+            </p>
           </div>
 
-          <div className="rounded-xl border border-[#D9E6FF] bg-white/90 px-4 py-3 text-right shadow-sm">
-            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#6B7280]">Match Score</p>
-            <p className="mt-1 text-2xl font-bold text-[#1A1D27]">{career.matchScore}%</p>
+          <div className="flex flex-col items-end gap-3">
+            <div className="rounded-xl border border-[#D9E6FF] bg-white/90 px-4 py-3 text-right shadow-sm">
+              <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[#6B7280]">Match Score</p>
+              <p className="mt-1 text-2xl font-bold text-[#1A1D27]">{career.matchScore}%</p>
+            </div>
+
+            <div className="flex flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                onClick={navigateToCareerSuggestions}
+                className="rounded-[10px] border border-[#E8EAF0] bg-white px-4 py-2 text-xs font-semibold text-[#6B7280] transition hover:border-[#CAD8F5] hover:bg-[#F7F8FA]"
+              >
+                Back to Suggestions
+              </button>
+              <button
+                type="button"
+                onClick={handleRegenerate}
+                disabled={isBusy}
+                className="rounded-[10px] border border-[#D4E0FA] bg-white px-4 py-2 text-xs font-semibold text-[#3B6FE8] transition hover:border-[#BFD4FF] hover:bg-[#EEF2FD] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isRegenerating ? 'Regenerating...' : 'Refresh & Regenerate'}
+              </button>
+            </div>
           </div>
         </div>
 
         <div className="mt-5 flex flex-wrap gap-2">
-          {career.matchedAreas.map((area) => (
+          {matchedAreas.map((area) => (
             <span key={area} className="rounded-full border border-[#DCE6FB] bg-[#F6F9FF] px-3 py-1 text-xs font-medium text-[#355188]">
               {area}
             </span>
           ))}
         </div>
+
+        {isRegenerating && (
+          <div className="mt-4 rounded-xl border border-[#D4E0FA] bg-white/95 px-4 py-3 text-sm font-semibold text-[#3B6FE8] shadow-sm animate-pulse">
+            {statusMessage}
+          </div>
+        )}
       </section>
 
       <section className="rounded-2xl border border-[#E8EAF0] bg-white/95 p-6 shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
-        <h2 className="text-lg font-bold text-[#1A1D27]">Comprehensive Description</h2>
+        <h2 className="text-lg font-bold text-[#1A1D27]">Comprehensive AI Analysis</h2>
         <p className="mt-3 text-sm leading-7 text-[#5F6C80]">{career.comprehensiveDescription}</p>
       </section>
+
+      {strengthsToLeverage.length > 0 && (
+        <section className="rounded-2xl border border-[#E8EAF0] bg-white/95 p-6 shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
+          <h2 className="text-lg font-bold text-[#1A1D27]">Strengths To Leverage</h2>
+          <ul className="mt-3 space-y-2 text-sm leading-7 text-[#5F6C80]">
+            {strengthsToLeverage.map((item) => (
+              <li key={item} className="flex gap-2">
+                <span className="mt-1 h-2 w-2 rounded-full bg-[#18A36E]" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {skillGaps.length > 0 && (
+        <section className="rounded-2xl border border-[#E8EAF0] bg-white/95 p-6 shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
+          <h2 className="text-lg font-bold text-[#1A1D27]">Priority Skill Gaps</h2>
+          <ul className="mt-3 space-y-2 text-sm leading-7 text-[#5F6C80]">
+            {skillGaps.map((item) => (
+              <li key={item} className="flex gap-2">
+                <span className="mt-1 h-2 w-2 rounded-full bg-[#F28B2E]" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       <section className="rounded-2xl border border-[#E8EAF0] bg-white/95 p-6 shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
         <h2 className="text-lg font-bold text-[#1A1D27]">Guideline</h2>
         <ol className="mt-3 space-y-2 text-sm leading-7 text-[#5F6C80]">
-          {career.guidelines.map((item) => (
+          {guidelines.map((item) => (
             <li key={item} className="flex gap-2">
               <span className="mt-1 h-2 w-2 rounded-full bg-[#3B6FE8]" />
               <span>{item}</span>
@@ -81,12 +267,37 @@ function CareerRoadmapDetail() {
       </section>
 
       <section className="rounded-2xl border border-[#E8EAF0] bg-white/95 p-6 shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
-        <h2 className="text-lg font-bold text-[#1A1D27]">Roadmap</h2>
+        <h2 className="text-lg font-bold text-[#1A1D27]">Complete Guided Roadmap</h2>
         <div className="mt-4 space-y-3">
-          {career.roadmap.map((step) => (
-            <article key={step.phase} className="rounded-xl border border-[#E3EAF8] bg-[#FAFCFF] p-4">
-              <p className="text-sm font-semibold text-[#1A1D27]">{step.phase}</p>
-              <p className="mt-1 text-sm leading-6 text-[#5F6C80]">{step.outcome}</p>
+          {roadmap.map((step, index) => (
+            <article key={`${step.phase}-${index}`} className="rounded-xl border border-[#E3EAF8] bg-[#FAFCFF] p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-sm font-semibold text-[#1A1D27]">{step.phase}</p>
+                {step.timeline ? (
+                  <span className="rounded-full border border-[#DCE6FB] bg-white px-3 py-1 text-xs font-semibold text-[#355188]">
+                    {step.timeline}
+                  </span>
+                ) : null}
+              </div>
+
+              <p className="mt-2 text-sm leading-6 text-[#5F6C80]">{step.objective}</p>
+
+              {Array.isArray(step.actions) && step.actions.length > 0 && (
+                <ul className="mt-3 space-y-1 text-sm leading-6 text-[#5F6C80]">
+                  {step.actions.map((action) => (
+                    <li key={action} className="flex gap-2">
+                      <span className="mt-1 h-2 w-2 rounded-full bg-[#3B6FE8]" />
+                      <span>{action}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {step.milestone ? (
+                <p className="mt-3 text-xs font-semibold uppercase tracking-[0.1em] text-[#6B7280]">
+                  Milestone: {step.milestone}
+                </p>
+              ) : null}
             </article>
           ))}
         </div>
@@ -95,35 +306,40 @@ function CareerRoadmapDetail() {
       <section className="rounded-2xl border border-[#E8EAF0] bg-white/95 p-6 shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
         <h2 className="text-lg font-bold text-[#1A1D27]">Recommended Next Step</h2>
         <p className="mt-3 text-sm leading-7 text-[#5F6C80]">{career.nextStep}</p>
+        {career.confidenceNote ? (
+          <p className="mt-3 rounded-lg border border-[#E3EAF8] bg-[#FAFCFF] px-3 py-2 text-xs font-medium text-[#5F6C80]">
+            {career.confidenceNote}
+          </p>
+        ) : null}
       </section>
 
       <section className="rounded-2xl border border-[#E8EAF0] bg-white/95 p-6 shadow-[0_1px_4px_rgba(0,0,0,0.04)] backdrop-blur-[1px]">
         <h2 className="text-lg font-bold text-[#1A1D27]">Explore Other Career Guides</h2>
         <div className="mt-4 grid gap-3 md:grid-cols-3">
-          {careerRoadmaps
-            .filter((item) => item.id !== career.id)
-            .map((item) => (
-              <Link
-                key={item.id}
-                to={`/student-guidance/career/${item.id}`}
-                className="rounded-xl border border-[#E3EAF8] bg-[#FAFCFF] p-4 text-sm font-semibold text-[#1A1D27] transition hover:border-[#BFD4FF] hover:bg-white"
-              >
-                {item.title}
-              </Link>
-            ))}
+          {relatedCareerSuggestions.map((item, index) => (
+            <Link
+              key={createCareerIdentifier(item, index)}
+              to={`/student-guidance/career/${encodeURIComponent(createCareerIdentifier(item, index))}`}
+              className="rounded-xl border border-[#E3EAF8] bg-[#FAFCFF] p-4 text-sm font-semibold text-[#1A1D27] transition hover:border-[#BFD4FF] hover:bg-white"
+            >
+              {item.title}
+            </Link>
+          ))}
         </div>
+
+        {relatedCareerSuggestions.length === 0 && (
+          <p className="mt-4 text-sm text-[#6B7280]">
+            Refresh your AI suggestions to explore more career-specific guides.
+          </p>
+        )}
 
         <div className="mt-5 flex">
           <button
             type="button"
-            onClick={() =>
-              navigate('/dashboard?tab=guidance', {
-                state: { tab: 'guidance', guidanceTab: 'careers' },
-              })
-            }
+            onClick={navigateToCareerSuggestions}
             className="rounded-[10px] border border-[#E8EAF0] px-4 py-2 text-sm font-semibold text-[#6B7280] transition hover:border-[#CAD8F5] hover:bg-[#F7F8FA]"
           >
-            Back
+            Back to Suggestions
           </button>
         </div>
       </section>

--- a/server/src/controllers/student_guidance/studentGuidanceController.js
+++ b/server/src/controllers/student_guidance/studentGuidanceController.js
@@ -3,10 +3,12 @@ const Student = require("../../models/Student");
 const StudentGuidance = require("../../models/student_guidance/StudentGuidance");
 const Career = require("../../models/student_guidance/Career");
 const StudentCareerSuggestion = require("../../models/student_guidance/StudentCareerSuggestion");
+const StudentCareerAnalysis = require("../../models/student_guidance/StudentCareerAnalysis");
 const OpenAI = require("openai");
 
 let openAIClient;
 const CAREER_SUGGESTION_LIMIT = 6;
+const CAREER_ROADMAP_PHASE_LIMIT = 6;
 
 const MARKDOWN_RESPONSE_GUIDELINES = [
     "Return ONLY Markdown.",
@@ -29,6 +31,59 @@ const normalizeItems = (items, mapper) => {
         .filter((item) => item && Object.values(item).every(Boolean));
 };
 
+const normalizeText = (value) => (typeof value === "string" ? value.trim() : "");
+
+const toSlug = (value) =>
+    normalizeText(String(value || ""))
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/(^-|-$)/g, "");
+
+const buildCareerIdentifier = (idCandidate, title, fallbackIndex = 0) => {
+    const directId = normalizeText(idCandidate ? String(idCandidate) : "");
+
+    if (directId) {
+        return directId;
+    }
+
+    const titleSlug = toSlug(title);
+
+    if (titleSlug) {
+        return titleSlug;
+    }
+
+    return `career-${fallbackIndex + 1}`;
+};
+
+const sanitizeStringArray = (items, limit = 8) => {
+    if (!Array.isArray(items)) {
+        return [];
+    }
+
+    return items
+        .map((item) => normalizeText(item))
+        .filter(Boolean)
+        .slice(0, limit);
+};
+
+const sanitizeRoadmapSteps = (steps) => {
+    if (!Array.isArray(steps)) {
+        return [];
+    }
+
+    return steps
+        .map((step, index) => ({
+            phase: normalizeText(step?.phase) || `Phase ${index + 1}`,
+            timeline: normalizeText(step?.timeline),
+            objective:
+                normalizeText(step?.objective) || normalizeText(step?.outcome),
+            actions: sanitizeStringArray(step?.actions, 5),
+            milestone: normalizeText(step?.milestone),
+        }))
+        .filter((step) => step.phase && step.objective)
+        .slice(0, CAREER_ROADMAP_PHASE_LIMIT);
+};
+
 const buildCareerSuggestions = async (guidance, examResults) => {
     const interestTags = guidance.interests.map((interest) => interest.name);
     const skillTags = guidance.skills.flatMap((skill) => [skill.name, skill.category]);
@@ -40,12 +95,15 @@ const buildCareerSuggestions = async (guidance, examResults) => {
     // Fetch active careers from database
     const careers = await Career.find({ isActive: true }).lean();
 
-    return careers.map((career) => ({
-        title: career.title,
-        summary: career.summary,
-        nextStep: career.nextStep,
-        matchScore: career.matchScore,
-        matchedAreas: career.matchTags.filter((tag) => tags.has(tag)).slice(0, 4),
+    return careers.map((career, index) => ({
+        id: buildCareerIdentifier(career?._id, career?.title, index),
+        title: normalizeText(career?.title),
+        summary: normalizeText(career?.summary),
+        nextStep: normalizeText(career?.nextStep),
+        matchScore: Number(career?.matchScore),
+        matchedAreas: Array.isArray(career?.matchTags)
+            ? career.matchTags.filter((tag) => tags.has(tag)).slice(0, 4)
+            : [],
     }));
 };
 
@@ -71,20 +129,17 @@ const sanitizeAISuggestions = (items) => {
     }
 
     return items
-        .map((item) => ({
-            title: typeof item?.title === "string" ? item.title.trim() : "",
-            summary: typeof item?.summary === "string" ? item.summary.trim() : "",
-            nextStep: typeof item?.nextStep === "string" ? item.nextStep.trim() : "",
+        .map((item, index) => ({
+            id: buildCareerIdentifier(item?.id, item?.title, index),
+            title: normalizeText(item?.title),
+            summary: normalizeText(item?.summary),
+            nextStep: normalizeText(item?.nextStep),
             matchScore: Number(item?.matchScore),
-            matchedAreas: Array.isArray(item?.matchedAreas)
-                ? item.matchedAreas
-                      .map((area) => (typeof area === "string" ? area.trim() : ""))
-                      .filter(Boolean)
-                      .slice(0, 5)
-                : [],
+            matchedAreas: sanitizeStringArray(item?.matchedAreas, 5),
         }))
         .filter(
             (item) =>
+                item.id &&
                 item.title &&
                 item.summary &&
                 item.nextStep &&
@@ -107,7 +162,7 @@ const generateAICareerSuggestions = async (context, catalogCareers) => {
             {
                 role: "developer",
                 content:
-                    "You generate personalized internship career suggestions for one student. Return only strict JSON with this shape: {\"suggestions\":[{\"title\":string,\"summary\":string,\"nextStep\":string,\"matchScore\":number,\"matchedAreas\":string[]}]}. No markdown.",
+                    "You generate personalized internship career suggestions for one student. Return only strict JSON with this shape: {\"suggestions\":[{\"id\":string,\"title\":string,\"summary\":string,\"nextStep\":string,\"matchScore\":number,\"matchedAreas\":string[]}]}. Use id values exactly from the provided career catalog. No markdown.",
             },
             {
                 role: "developer",
@@ -128,18 +183,288 @@ const generateAICareerSuggestions = async (context, catalogCareers) => {
     return sanitizeAISuggestions(payload?.suggestions);
 };
 
+const sanitizeAICareerDetail = (payload, selectedSuggestion) => {
+    if (!payload || typeof payload !== "object") {
+        return null;
+    }
+
+    const roadmap = sanitizeRoadmapSteps(payload.roadmap);
+    const comprehensiveDescription = normalizeText(payload.comprehensiveDescription);
+    const nextStep =
+        normalizeText(payload.nextStep) || normalizeText(selectedSuggestion?.nextStep);
+
+    const selectedMatchScore = Number(selectedSuggestion?.matchScore);
+
+    const normalizedDetail = {
+        id: buildCareerIdentifier(selectedSuggestion?.id, selectedSuggestion?.title),
+        title: normalizeText(selectedSuggestion?.title),
+        summary: normalizeText(selectedSuggestion?.summary),
+        matchScore: Number.isFinite(selectedMatchScore)
+            ? Math.max(0, Math.min(100, Math.round(selectedMatchScore)))
+            : 0,
+        matchedAreas: sanitizeStringArray(selectedSuggestion?.matchedAreas, 6),
+        comprehensiveDescription,
+        strengthsToLeverage: sanitizeStringArray(payload.strengthsToLeverage, 6),
+        skillGaps: sanitizeStringArray(payload.skillGaps, 6),
+        guidelines: sanitizeStringArray(payload.guidelines, 8),
+        roadmap,
+        nextStep,
+        confidenceNote: normalizeText(payload.confidenceNote),
+    };
+
+    if (
+        !normalizedDetail.title ||
+        !normalizedDetail.comprehensiveDescription ||
+        !normalizedDetail.guidelines.length ||
+        !normalizedDetail.roadmap.length ||
+        !normalizedDetail.nextStep
+    ) {
+        return null;
+    }
+
+    return normalizedDetail;
+};
+
+const buildFallbackCareerDetail = (selectedSuggestion, context) => {
+    const interestSignals = sanitizeStringArray(
+        context?.studentGuidance?.interests?.map((item) => item?.name),
+        3
+    );
+    const skillSignals = sanitizeStringArray(
+        context?.studentGuidance?.skills?.map((item) => item?.name),
+        3
+    );
+    const matchedAreas = sanitizeStringArray(selectedSuggestion?.matchedAreas, 6);
+
+    const strengthsToLeverage =
+        sanitizeStringArray(
+            [...interestSignals, ...skillSignals, ...matchedAreas],
+            6
+        ) || [];
+
+    return {
+        id: buildCareerIdentifier(selectedSuggestion?.id, selectedSuggestion?.title),
+        title: normalizeText(selectedSuggestion?.title),
+        summary: normalizeText(selectedSuggestion?.summary),
+        matchScore: Number.isFinite(Number(selectedSuggestion?.matchScore))
+            ? Math.max(0, Math.min(100, Math.round(Number(selectedSuggestion?.matchScore))))
+            : 0,
+        matchedAreas,
+        comprehensiveDescription:
+            `${normalizeText(selectedSuggestion?.title)} aligns with your profile based on your selected interests, ` +
+            "skills, and academic progress. Follow this guided plan to build practical capability, " +
+            "close key gaps, and create portfolio evidence for internship applications.",
+        strengthsToLeverage:
+            strengthsToLeverage.length > 0
+                ? strengthsToLeverage
+                : [
+                      "Consistent learning habits",
+                      "Structured project execution",
+                      "Clear communication of technical decisions",
+                  ],
+        skillGaps: [
+            "Real-world project depth with measurable outcomes",
+            "Interview-focused problem solving under time constraints",
+            "Documentation and presentation of implementation decisions",
+        ],
+        guidelines: [
+            "Set one measurable weekly objective and track completion status.",
+            "Translate each concept into a practical mini-project before moving forward.",
+            "Request feedback from mentors or peers every two weeks and apply improvements.",
+            "Document each project using clear architecture notes, trade-offs, and results.",
+            "Align portfolio work with internship role descriptions and assessment criteria.",
+        ],
+        roadmap: [
+            {
+                phase: "Phase 1: Direction & Baseline",
+                timeline: "Week 1",
+                objective:
+                    "Define role targets, assess current level, and prioritize required competencies.",
+                actions: [
+                    "Review internship job descriptions for this role and list required skills.",
+                    "Run a personal skill audit and identify top three improvement priorities.",
+                    "Create a weekly study and build schedule with milestones.",
+                ],
+                milestone: "Approved 8-10 week learning plan with clear outcomes.",
+            },
+            {
+                phase: "Phase 2: Core Skill Build",
+                timeline: "Weeks 2-3",
+                objective:
+                    "Strengthen technical fundamentals and complete focused practice tasks.",
+                actions: [
+                    "Study core concepts daily and complete short implementation exercises.",
+                    "Build two feature-focused mini projects to verify understanding.",
+                    "Capture common mistakes and corrective patterns in learning notes.",
+                ],
+                milestone: "Two working mini projects demonstrating core competencies.",
+            },
+            {
+                phase: "Phase 3: Guided Project Sprint",
+                timeline: "Weeks 4-5",
+                objective:
+                    "Build one portfolio-ready project with realistic workflow and delivery standards.",
+                actions: [
+                    "Define project scope, user stories, and implementation plan.",
+                    "Ship features in weekly increments and maintain quality checks.",
+                    "Record design decisions and technical trade-offs.",
+                ],
+                milestone: "Portfolio project v1 delivered with documentation.",
+            },
+            {
+                phase: "Phase 4: Industry Readiness",
+                timeline: "Weeks 6-7",
+                objective:
+                    "Improve reliability, testing discipline, and communication quality.",
+                actions: [
+                    "Add validation and test critical scenarios where possible.",
+                    "Refine UX and performance using mentor or peer feedback.",
+                    "Prepare a concise project walkthrough and technical summary.",
+                ],
+                milestone: "Production-quality project iteration with polished presentation.",
+            },
+            {
+                phase: "Phase 5: Interview & Application Sprint",
+                timeline: "Weeks 8-9",
+                objective:
+                    "Translate project evidence into interview and application readiness.",
+                actions: [
+                    "Build role-specific resume bullets with measurable impact statements.",
+                    "Practice behavioral and technical interview questions.",
+                    "Prepare STAR stories from project decisions and outcomes.",
+                ],
+                milestone:
+                    "Application package completed with portfolio, resume, and interview narratives.",
+            },
+            {
+                phase: "Phase 6: Launch & Iterate",
+                timeline: "Week 10",
+                objective:
+                    "Apply to targeted internships and continuously refine based on outcomes.",
+                actions: [
+                    "Submit applications in focused batches and track responses.",
+                    "Review rejection/feedback signals and update weak areas quickly.",
+                    "Set the next 30-day upskilling plan while interviewing.",
+                ],
+                milestone: "Active internship pipeline with a repeatable improvement loop.",
+            },
+        ],
+        nextStep:
+            normalizeText(selectedSuggestion?.nextStep) ||
+            "Start Phase 1 today by defining your target role checklist and weekly plan.",
+        confidenceNote:
+            "AI detail generation was unavailable, so this roadmap was auto-generated from your saved profile context.",
+    };
+};
+
+const generateAICareerDetail = async (
+    context,
+    selectedSuggestion,
+    allSuggestions = []
+) => {
+    const client = getOpenAIClient();
+
+    const alternatives = sanitizeAISuggestions(allSuggestions)
+        .filter((item) => item.id !== selectedSuggestion.id)
+        .slice(0, 3)
+        .map((item) => ({
+            id: item.id,
+            title: item.title,
+            summary: item.summary,
+            matchScore: item.matchScore,
+        }));
+
+    const response = await client.responses.create({
+        model: process.env.OPENAI_MODEL || "gpt-5",
+        reasoning: { effort: "medium" },
+        input: [
+            {
+                role: "developer",
+                content:
+                    "You generate a complete personalized career analysis and guided roadmap for one student. Return only strict JSON with this shape: {\"comprehensiveDescription\":string,\"strengthsToLeverage\":string[],\"skillGaps\":string[],\"guidelines\":string[],\"roadmap\":[{\"phase\":string,\"timeline\":string,\"objective\":string,\"actions\":string[],\"milestone\":string}],\"nextStep\":string,\"confidenceNote\":string}. No markdown.",
+            },
+            {
+                role: "developer",
+                content:
+                    "Use only the student context provided. Do not invent grades, modules, or profile facts.",
+            },
+            {
+                role: "developer",
+                content: `Student academic context (JSON): ${JSON.stringify(context)}`,
+            },
+            {
+                role: "developer",
+                content: `Selected career suggestion (JSON): ${JSON.stringify(selectedSuggestion)}`,
+            },
+            {
+                role: "developer",
+                content: `Alternative career suggestions (JSON): ${JSON.stringify(alternatives)}`,
+            },
+            {
+                role: "user",
+                content:
+                    "Generate a full analysis with a complete guided roadmap for the selected career suggestion.",
+            },
+        ],
+    });
+
+    const payload = extractJsonFromText(response.output_text || "");
+    return sanitizeAICareerDetail(payload, selectedSuggestion);
+};
+
+const getStoredCareerAnalysis = async (studentId, careerId) => {
+    return StudentCareerAnalysis.findOne({
+        student: studentId,
+        careerId,
+    }).lean();
+};
+
+const saveCareerAnalysis = async ({ studentId, careerId, report, source }) => {
+    if (!report || typeof report !== "object") {
+        return null;
+    }
+
+    return StudentCareerAnalysis.findOneAndUpdate(
+        {
+            student: studentId,
+            careerId,
+        },
+        {
+            student: studentId,
+            careerId,
+            report,
+            source: source === "fallback" ? "fallback" : "ai",
+            generatedAt: new Date(),
+        },
+        {
+            upsert: true,
+            new: true,
+            setDefaultsOnInsert: true,
+        }
+    );
+};
+
 const getStoredCareerSuggestions = async (studentId) => {
     const record = await StudentCareerSuggestion.findOne({ student: studentId }).lean();
-    return Array.isArray(record?.suggestions) ? record.suggestions : [];
+    return sanitizeAISuggestions(record?.suggestions || []);
 };
 
 const refreshCareerSuggestionsForStudent = async (studentId, guidance, examResults) => {
-    const [context, catalogCareers] = await Promise.all([
+    const [context, catalogCareersRaw] = await Promise.all([
         buildAcademicContext(studentId),
         Career.find({ isActive: true })
             .select("title summary nextStep matchTags matchScore")
             .lean(),
     ]);
+
+    const catalogCareers = catalogCareersRaw.map((career, index) => ({
+        id: buildCareerIdentifier(career?._id, career?.title, index),
+        title: normalizeText(career?.title),
+        summary: normalizeText(career?.summary),
+        nextStep: normalizeText(career?.nextStep),
+        matchTags: sanitizeStringArray(career?.matchTags, 10),
+        matchScore: Number(career?.matchScore),
+    }));
 
     let aiSuggestions = [];
 
@@ -150,7 +475,9 @@ const refreshCareerSuggestionsForStudent = async (studentId, guidance, examResul
     }
 
     const fallbackSuggestions = await buildCareerSuggestions(guidance, examResults);
-    const nextSuggestions = aiSuggestions.length ? aiSuggestions : fallbackSuggestions;
+    const nextSuggestions = sanitizeAISuggestions(
+        aiSuggestions.length ? aiSuggestions : fallbackSuggestions
+    );
 
     await StudentCareerSuggestion.findOneAndUpdate(
         { student: studentId },
@@ -414,6 +741,112 @@ const refreshCareerSuggestions = async (req, res, next) => {
     }
 };
 
+const getCareerAnalysis = async (req, res, next) => {
+    try {
+        const requestedCareerId = normalizeText(req.params?.careerId);
+        const refreshQuery = normalizeText(req.query?.refresh).toLowerCase();
+        const forceRefresh = ["1", "true", "yes", "refresh", "regenerate"].includes(
+            refreshQuery
+        );
+
+        if (!requestedCareerId) {
+            return res.status(400).json({
+                success: false,
+                message: "Career id is required",
+            });
+        }
+
+        const guidance = await getOrCreateStudentGuidance(req.student._id);
+        const examResults = await getStudentExamResults(req.student._id);
+        let careerSuggestions = await getStoredCareerSuggestions(req.student._id);
+
+        if (!careerSuggestions.length) {
+            careerSuggestions = await refreshCareerSuggestionsForStudent(
+                req.student._id,
+                guidance,
+                examResults
+            );
+        }
+
+        const selectedSuggestion =
+            careerSuggestions.find((item) => item.id === requestedCareerId) ||
+            careerSuggestions.find(
+                (item) =>
+                    toSlug(item.title) === requestedCareerId ||
+                    buildCareerIdentifier(item.id, item.title) === requestedCareerId
+            );
+
+        if (!selectedSuggestion) {
+            return res.status(404).json({
+                success: false,
+                message: "Career guide not found for this suggestion",
+            });
+        }
+
+        if (!forceRefresh) {
+            const cachedAnalysis = await getStoredCareerAnalysis(
+                req.student._id,
+                selectedSuggestion.id
+            );
+
+            const cachedReport = sanitizeAICareerDetail(
+                cachedAnalysis?.report,
+                selectedSuggestion
+            );
+
+            if (cachedReport) {
+                return res.status(200).json({
+                    success: true,
+                    data: cachedReport,
+                    meta: {
+                        source: cachedAnalysis?.source || "ai",
+                        cached: true,
+                        generatedAt: cachedAnalysis?.generatedAt || null,
+                    },
+                });
+            }
+        }
+
+        const context = await buildAcademicContext(req.student._id);
+
+        let aiDetail = null;
+
+        try {
+            aiDetail = await generateAICareerDetail(
+                context,
+                selectedSuggestion,
+                careerSuggestions
+            );
+        } catch {
+            aiDetail = null;
+        }
+
+        const responseData =
+            aiDetail || buildFallbackCareerDetail(selectedSuggestion, context);
+
+        const analysisSource = aiDetail ? "ai" : "fallback";
+
+        await saveCareerAnalysis({
+            studentId: req.student._id,
+            careerId: selectedSuggestion.id,
+            report: responseData,
+            source: analysisSource,
+        });
+
+        return res.status(200).json({
+            success: true,
+            data: responseData,
+            meta: {
+                source: analysisSource,
+                cached: false,
+                generatedAt: new Date(),
+            },
+        });
+    } catch (error) {
+        return next(error);
+    }
+};
+
 const askInternConnect = async (req, res, next) => {
     let streamClosed = false;
 
@@ -522,6 +955,7 @@ const askInternConnect = async (req, res, next) => {
 
 module.exports = {
     askInternConnect,
+    getCareerAnalysis,
     getStudentGuidance,
     refreshCareerSuggestions,
     updateStudentInterests,

--- a/server/src/models/student_guidance/StudentCareerAnalysis.js
+++ b/server/src/models/student_guidance/StudentCareerAnalysis.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+
+const studentCareerAnalysisSchema = new mongoose.Schema(
+    {
+        student: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "Student",
+            required: true,
+            index: true,
+        },
+        careerId: {
+            type: String,
+            required: true,
+            trim: true,
+        },
+        report: {
+            type: mongoose.Schema.Types.Mixed,
+            required: true,
+        },
+        source: {
+            type: String,
+            enum: ["ai", "fallback"],
+            default: "ai",
+        },
+        generatedAt: {
+            type: Date,
+            default: Date.now,
+        },
+    },
+    {
+        timestamps: true,
+    }
+);
+
+studentCareerAnalysisSchema.index({ student: 1, careerId: 1 }, { unique: true });
+
+module.exports = mongoose.model("StudentCareerAnalysis", studentCareerAnalysisSchema);

--- a/server/src/models/student_guidance/StudentCareerSuggestion.js
+++ b/server/src/models/student_guidance/StudentCareerSuggestion.js
@@ -2,6 +2,11 @@ const mongoose = require("mongoose");
 
 const suggestionSchema = new mongoose.Schema(
     {
+        id: {
+            type: String,
+            required: true,
+            trim: true,
+        },
         title: {
             type: String,
             required: true,

--- a/server/src/routes/student_guidance/studentGuidanceRoutes.js
+++ b/server/src/routes/student_guidance/studentGuidanceRoutes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const protect = require("../../middleware/authMiddleware");
 const {
     askInternConnect,
+    getCareerAnalysis,
     getStudentGuidance,
     refreshCareerSuggestions,
     updateStudentInterests,
@@ -14,6 +15,7 @@ router.get("/", protect, getStudentGuidance);
 router.put("/interests", protect, updateStudentInterests);
 router.put("/skills", protect, updateStudentSkills);
 router.post("/career-suggestions/refresh", protect, refreshCareerSuggestions);
+router.get("/career-suggestions/:careerId/analysis", protect, getCareerAnalysis);
 router.post("/chat", protect, askInternConnect);
 
 module.exports = router;


### PR DESCRIPTION
Add end-to-end support for AI-generated per-career analysis and guided roadmap. Server: introduce StudentCareerAnalysis model, add getCareerAnalysis controller (AI generation, sanitization, fallback builder, caching and force-refresh support), extend suggestion sanitization to include stable ids, normalize/sanitize utilities, and save/load analysis. Update student guidance routes to expose /career-suggestions/:careerId/analysis. Client: add fetchCareerAnalysis API, update CareerSuggestionsSection to create stable career identifiers, use memoization, and link to encoded analysis route. Implement CareerRoadmapDetail page to fetch/display the AI analysis (loading/regeneration states, status messages, strengths, skill gaps, guidelines, detailed roadmap, confidence note, and related suggestion links). Misc: update StudentCareerSuggestion schema to include id and adjust suggestion generation contract to return ids. These changes enable cached AI analysis per student+career with graceful fallbacks and UI controls for regeneration.